### PR TITLE
Make `invoke` on the server asynchronous

### DIFF
--- a/demo/Server/SignalR.fs
+++ b/demo/Server/SignalR.fs
@@ -4,13 +4,17 @@ module SignalRHub =
     open Fable.SignalR
     open FSharp.Control
     open SignalRHub
-
+    open FSharp.Control.Tasks.V2
+    
     let update (msg: Action) =
         match msg with
         | Action.IncrementCount i -> Response.NewCount(i + 1)
         | Action.DecrementCount i -> Response.NewCount(i - 1)
 
-    let invoke (msg: Action) (services: System.IServiceProvider) = update msg
+    let invoke (msg: Action) (services: System.IServiceProvider) =
+        task {
+            return update msg
+        }
 
     let send (msg: Action) (hubContext: FableHub<Action,Response>) =
         update msg

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -18,6 +18,7 @@ group Fable.SignalR.AspNetCore
     nuget Fable.Remoting.Json ~> 2
     nuget FSharp.Core ~> 4.7
     nuget Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson ~> 3
+    nuget TaskBuilder.fs
 
 group Fable.SignalR.Elmish
     source https://nuget.org/api/v2

--- a/src/Fable.SignalR.AspNetCore/AspNetCore.fs
+++ b/src/Fable.SignalR.AspNetCore/AspNetCore.fs
@@ -112,14 +112,14 @@ module SignalRExtension =
             |> Impl.config<StreamBothFableHub<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi,'ServerStreamApi>> this hubOptions
         
         /// Adds SignalR services to the specified Microsoft.Extensions.DependencyInjection.IServiceCollection.
-        member this.AddSignalR(endpoint: string, update: 'ClientApi -> FableHub<'ClientApi,'ServerApi> -> #Task, invoke: 'ClientApi -> System.IServiceProvider -> 'ServerApi) =
+        member this.AddSignalR(endpoint: string, update: 'ClientApi -> FableHub<'ClientApi,'ServerApi> -> #Task, invoke: 'ClientApi -> System.IServiceProvider -> Task<'ServerApi>) =
             SignalR.ConfigBuilder(endpoint, Task.toGen update, invoke).Build()
             |> this.AddSignalR
 
         member this.AddSignalR
             (endpoint: string,
              update: 'ClientApi -> FableHub<'ClientApi,'ServerApi> -> #Task,
-             invoke: 'ClientApi -> System.IServiceProvider -> 'ServerApi,
+             invoke: 'ClientApi -> System.IServiceProvider -> Task<'ServerApi>,
              streamFrom: 'ClientStreamApi -> FableHub<'ClientApi,'ServerApi> -> IAsyncEnumerable<'ServerStreamApi>) =
             
             this.AddSignalR(SignalR.ConfigBuilder(endpoint, Task.toGen update, invoke).Build(), streamFrom)
@@ -128,7 +128,7 @@ module SignalRExtension =
         member this.AddSignalR
             (endpoint: string,
              update: 'ClientApi -> FableHub<'ClientApi,'ServerApi> -> #Task,
-             invoke: 'ClientApi -> System.IServiceProvider -> 'ServerApi,
+             invoke: 'ClientApi -> System.IServiceProvider -> Task<'ServerApi>,
              streamTo: IAsyncEnumerable<'ClientStreamApi> -> FableHub<'ClientApi,'ServerApi> -> #Task) =
             
             this.AddSignalR(SignalR.ConfigBuilder(endpoint, Task.toGen update, invoke).Build(), Task.toGen streamTo)
@@ -137,7 +137,7 @@ module SignalRExtension =
         member this.AddSignalR
             (endpoint: string,
              update: 'ClientApi -> FableHub<'ClientApi,'ServerApi> -> #Task,
-             invoke: 'ClientApi -> System.IServiceProvider -> 'ServerApi,
+             invoke: 'ClientApi -> System.IServiceProvider -> Task<'ServerApi>,
              streamFrom: 'ClientStreamFromApi -> FableHub<'ClientApi,'ServerApi> -> IAsyncEnumerable<'ServerStreamApi>,
              streamTo: IAsyncEnumerable<'ClientStreamToApi> -> FableHub<'ClientApi,'ServerApi> -> #Task) =
             
@@ -147,7 +147,7 @@ module SignalRExtension =
         member this.AddSignalR
             (endpoint: string,
              update: 'ClientApi -> FableHub<'ClientApi,'ServerApi> -> #Task,
-             invoke: 'ClientApi -> System.IServiceProvider -> 'ServerApi,
+             invoke: 'ClientApi -> System.IServiceProvider -> Task<'ServerApi>,
              config: SignalR.ConfigBuilder<'ClientApi,'ServerApi> -> SignalR.ConfigBuilder<'ClientApi,'ServerApi>) =
 
             SignalR.ConfigBuilder(endpoint, Task.toGen update, invoke) 
@@ -159,7 +159,7 @@ module SignalRExtension =
         member this.AddSignalR
             (endpoint: string,
              update: 'ClientApi -> FableHub<'ClientApi,'ServerApi> -> #Task,
-             invoke: 'ClientApi -> System.IServiceProvider -> 'ServerApi,
+             invoke: 'ClientApi -> System.IServiceProvider -> Task<'ServerApi>,
              streamFrom: 'ClientStreamApi -> FableHub<'ClientApi,'ServerApi> -> IAsyncEnumerable<'ServerStreamApi>,
              config: SignalR.ConfigBuilder<'ClientApi,'ServerApi> -> SignalR.ConfigBuilder<'ClientApi,'ServerApi>) =
 
@@ -171,7 +171,7 @@ module SignalRExtension =
         member this.AddSignalR
             (endpoint: string,
              update: 'ClientApi -> FableHub<'ClientApi,'ServerApi> -> #Task,
-             invoke: 'ClientApi -> System.IServiceProvider -> 'ServerApi,
+             invoke: 'ClientApi -> System.IServiceProvider -> Task<'ServerApi>,
              streamTo: IAsyncEnumerable<'ClientStreamApi> -> FableHub<'ClientApi,'ServerApi> -> #Task,
              config: SignalR.ConfigBuilder<'ClientApi,'ServerApi> -> SignalR.ConfigBuilder<'ClientApi,'ServerApi>) =
 
@@ -183,7 +183,7 @@ module SignalRExtension =
         member this.AddSignalR
             (endpoint: string,
              update: 'ClientApi -> FableHub<'ClientApi,'ServerApi> -> #Task,
-             invoke: 'ClientApi -> System.IServiceProvider -> 'ServerApi,
+             invoke: 'ClientApi -> System.IServiceProvider -> Task<'ServerApi>,
              streamFrom: 'ClientStreamFromApi -> FableHub<'ClientApi,'ServerApi> -> IAsyncEnumerable<'ServerStreamApi>,
              streamTo: IAsyncEnumerable<'ClientStreamToApi> -> FableHub<'ClientApi,'ServerApi> -> #Task,
              config: SignalR.ConfigBuilder<'ClientApi,'ServerApi> -> SignalR.ConfigBuilder<'ClientApi,'ServerApi>) =

--- a/src/Fable.SignalR.AspNetCore/paket.references
+++ b/src/Fable.SignalR.AspNetCore/paket.references
@@ -2,3 +2,4 @@
     Fable.Remoting.Json
     FSharp.Core
     Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson
+    TaskBuilder.fs

--- a/src/Fable.SignalR.Saturn/Saturn.fs
+++ b/src/Fable.SignalR.Saturn/Saturn.fs
@@ -58,7 +58,7 @@ module SignalRExtension =
                 
             /// Handler for client invocations.
             [<CustomOperation("invoke")>]
-            member _.Invoke (State.Send.Value (endpoint,send), f: 'a -> System.IServiceProvider ->'b) = 
+            member _.Invoke (State.Send.Value (endpoint,send), f: 'a -> System.IServiceProvider -> Task<'b>) = 
 
                 let settings : SignalR.Settings<'a,'b> =
                     { EndpointPattern = endpoint


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request. -->
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`fake build` or `.\build.cmd`) on local branch was successful

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The `invoke` function on the server is synchronous and has the signature `'ClientApi -> IServiceProvider -> 'ServerApi`.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Now the `invoke` function on the server is asynchronous and has the signature `'ClientApi -> IServiceProvider -> Task<'ServerApi>`.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

You will need to add `Task.FromResult(...)` or `task { return ... }` to all your `invoke` functions on the server.

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

I could not build with `fake build` because there were problems with yarn, but the demo worked successfully.