### PR TITLE
JsonProtocol.writeMessage: use Json.serialize instead of stringify (Fable 3 warning)

### DIFF
--- a/src/Fable.SignalR/Protocols.fs
+++ b/src/Fable.SignalR/Protocols.fs
@@ -163,7 +163,7 @@ module Protocol =
 
         type JsonProtocol () =
             member inline _.writeMessage (message: HubMessage<'ClientStreamFromApi,'ClientApi,'ClientApi,'ClientStreamToApi>) =
-                TextMessageFormat.write(Json.stringify message)
+                TextMessageFormat.write(Json.serialize message)
                 |> U2.Case1
 
             member inline _.processMsg<'ServerApi,'ServerStreamApi> (parsedRaw: Json, msgType: MessageType) =


### PR DESCRIPTION
Following SimpleJson's recommentation in a warning when building with
Fable 3:

> It looks like you using the function Json.stringify from
> Fable.SimpleJson while also using Fable 3 (nagareyama). Please use
> Json.serialize instead which supports both Fable 3 and Fable 2.x

According to Zaid (the author) this function results in the same output:

https://github.com/Zaid-Ajaj/Fable.SimpleJson/issues/57

<!-- Please refer to our contributing documentation for any questions on submitting a pull request. -->
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
  - n/a
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
  - n/a
- [x] Build (`fake build` or `.\build.cmd`) on local branch was successful

Fake's Dotnet.restore seems to have an issue. I was not able to restore this way, and therefor not able to use the build.fsx.

```
Finished (Failed) 'DotNet:restore' in 00:00:25.5349290
Task failed with Value cannot be null. (Parameter 'format')
```

A manual `dotnet build Fable.SignalR.sln` did finish successfully though.

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
SimpleJson's stringify outputs a warning when used with Fable 3.

## What is the new behavior?
SimpleJson's serialize does not output a warning.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
