### PR TITLE
Allow .NET clients to cancel streams started with StreamFrom

### DIFF
--- a/src/Fable.SignalR.DotNet/HubConnection.fs
+++ b/src/Fable.SignalR.DotNet/HubConnection.fs
@@ -8,7 +8,7 @@ open System.Threading
 open System.Threading.Tasks
 
 type internal IHubConnection<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi,'ServerStreamApi> (hub: HubConnection) =
-    member _.ConnectionId = 
+    member _.ConnectionId =
         match hub.ConnectionId with
         | null -> None
         | id -> Some id
@@ -22,12 +22,12 @@ type internal IHubConnection<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,
         |> Async.AwaitTask
 
     member _.KeepAliveInterval = hub.KeepAliveInterval
-    
-    member _.OnClosed (f: exn option -> Async<unit>) = 
+
+    member _.OnClosed (f: exn option -> Async<unit>) =
         wrapEvent f
         |> hub.add_Closed
-    
-    member _.OnMessage (callback: 'ServerApi -> Async<unit>) = 
+
+    member _.OnMessage (callback: 'ServerApi -> Async<unit>) =
         hub.On<'ServerApi>(HubMethod.Send, System.Func<'ServerApi,Task>(callback >> Async.StartAsTask >> genTask))
 
     member _.OnReconnecting (f: exn option -> Async<unit>) =
@@ -38,10 +38,10 @@ type internal IHubConnection<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,
         wrapEvent f
         |> hub.add_Reconnected
 
-    member _.RemoveClosed (f: exn option -> Async<unit>) = 
+    member _.RemoveClosed (f: exn option -> Async<unit>) =
         wrapEvent f
         |> hub.remove_Closed
-    
+
     member _.RemoveInvoke () = hub.Remove(HubMethod.Invoke)
 
     member _.RemoveReconnecting (f: exn option -> Async<unit>) =
@@ -51,48 +51,48 @@ type internal IHubConnection<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,
     member _.RemoveReconnected (f: string option -> Async<unit>) =
         wrapEvent f
         |> hub.remove_Reconnected
-    
+
     member _.RemoveSend () = hub.Remove(HubMethod.Send)
-    
-    member _.Send (msg: 'ClientApi, ?cancellationToken: CancellationToken) = 
+
+    member _.Send (msg: 'ClientApi, ?cancellationToken: CancellationToken) =
         match cancellationToken with
         | Some ct -> hub.SendAsync(HubMethod.Send, msg, ct)
         | None -> hub.SendAsync(HubMethod.Send, msg)
         |> Async.AwaitTask
 
-    member this.SendNow (msg: 'ClientApi, ?cancellationToken: CancellationToken) = 
+    member this.SendNow (msg: 'ClientApi, ?cancellationToken: CancellationToken) =
         this.Send(msg, ?cancellationToken = cancellationToken)
         |> Async.Start
 
     member _.ServerTimeout = hub.ServerTimeout
-    
+
     member _.Start (?cancellationToken: CancellationToken) =
         match cancellationToken with
         | Some ct -> hub.StartAsync(ct)
         | None -> hub.StartAsync()
         |> Async.AwaitTask
 
-    member this.StartNow (?cancellationToken: CancellationToken) = 
+    member this.StartNow (?cancellationToken: CancellationToken) =
         this.Start(?cancellationToken = cancellationToken)
         |> Async.Start
 
     member _.State = hub.State
-    
-    member _.Stop (?cancellationToken: CancellationToken) = 
+
+    member _.Stop (?cancellationToken: CancellationToken) =
         match cancellationToken with
         | Some ct -> hub.StopAsync(ct)
         | None -> hub.StopAsync()
         |> Async.AwaitTask
 
-    member this.StopNow (?cancellationToken: CancellationToken) = 
+    member this.StopNow (?cancellationToken: CancellationToken) =
         this.Stop(?cancellationToken = cancellationToken)
         |> Async.Start
-        
+
     member _.StreamFrom (msg: 'ClientStreamFromApi, ?cancellationToken: CancellationToken) =
         match cancellationToken with
         | Some ct -> hub.StreamAsync<'ServerStreamApi>(HubMethod.StreamFrom, msg, ct)
         | None -> hub.StreamAsync<'ServerStreamApi>(HubMethod.StreamFrom, msg)
-    
+
     member _.StreamTo (asyncEnum: IAsyncEnumerable<'ClientStreamToApi>, ?cancellationToken: CancellationToken) =
         match cancellationToken with
         | Some ct -> hub.SendAsync(HubMethod.StreamTo, asyncEnum, ct)
@@ -107,33 +107,33 @@ type internal IHubConnection<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,
 type Hub<'ClientApi,'ServerApi> =
     /// The connectionId to the hub of this client.
     abstract ConnectionId : string option
-    
+
     /// Invokes a hub method on the server.
-    /// 
-    /// This method resolves when the server indicates it has finished invoking the method. 
-    /// When it finishes, the server has finished invoking the method. If the server 
+    ///
+    /// This method resolves when the server indicates it has finished invoking the method.
+    /// When it finishes, the server has finished invoking the method. If the server
     /// method returns a result, it is produced as the result of resolving the async call.
     abstract Invoke: msg: 'ClientApi -> Async<'ServerApi>
 
     /// Default interval at which to ping the server.
-    /// 
+    ///
     /// The default value is 15,000 milliseconds (15 seconds).
     /// Allows the server to detect hard disconnects (like when a client unplugs their computer).
     abstract KeepAliveInterval : TimeSpan
-    
+
     /// Invokes a hub method on the server. Does not wait for a response from the receiver.
-    /// 
-    /// The async returned by this method resolves when the client has sent the invocation to the server. 
+    ///
+    /// The async returned by this method resolves when the client has sent the invocation to the server.
     /// The server may still be processing the invocation.
     abstract Send: msg: 'ClientApi * ?cancellationToken: CancellationToken -> Async<unit>
-    
+
     /// Invokes a hub method on the server. Does not wait for a response from the receiver. The server may still
     /// be processing the invocation.
     abstract SendNow: msg: 'ClientApi * ?cancellationToken: CancellationToken -> unit
 
     /// The server timeout in milliseconds.
-    /// 
-    /// If this timeout elapses without receiving any messages from the server, the connection will be 
+    ///
+    /// If this timeout elapses without receiving any messages from the server, the connection will be
     /// terminated with an error.
     ///
     /// The default timeout value is 30,000 milliseconds (30 seconds).
@@ -153,20 +153,20 @@ module StreamHub =
 
         /// Streams to the hub immediately.
         abstract StreamToNow: asyncEnum: IAsyncEnumerable<'ClientStreamApi> * ?cancellationToken: CancellationToken -> unit
-    
+
     // fsharplint:disable-next-line
     type ServerToClient<'ClientApi,'ClientStreamApi,'ServerApi,'ServerStreamApi> =
         inherit Hub<'ClientApi,'ServerApi>
 
         /// Streams from the hub.
         abstract StreamFrom: msg: 'ClientStreamApi -> Async<IAsyncEnumerable<'ServerStreamApi>>
-        
+
     // fsharplint:disable-next-line
-    type Bidrectional<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi,'ServerStreamApi> = 
+    type Bidrectional<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi,'ServerStreamApi> =
         inherit Hub<'ClientApi,'ServerApi>
         inherit ClientToServer<'ClientApi,'ClientStreamToApi,'ServerApi>
         inherit ServerToClient<'ClientApi,'ClientStreamFromApi,'ServerApi,'ServerStreamApi>
-    
+
 [<NoComparison;NoEquality>]
 [<RequireQualifiedAccess>]
 type internal HubMailbox<'ClientApi,'ServerApi> =
@@ -195,7 +195,7 @@ type HubConnection<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi
     internal (hub: IHubConnection<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi,'ServerStreamApi>, handlers: Handlers) =
 
     let cts = new CancellationTokenSource()
-    
+
     let getLinkedCT (ct: CancellationToken option) =
         match ct with
         | None -> cts.Token
@@ -206,7 +206,7 @@ type HubConnection<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi
             pendingActions
             |> List.iter (fun a -> Async.StartImmediate(a(), cts.Token))
         }
-        
+
     let mailbox =
         MailboxProcessor.Start (fun inbox ->
             let rec loop (waitingInvocations: Map<System.Guid,AsyncReplyChannel<'ServerApi>>) (waitingConnections: (unit -> Async<unit>) list) =
@@ -219,9 +219,9 @@ type HubConnection<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi
                         else waitingConnections
 
                     let! msg = inbox.Receive()
-                    
+
                     let hubId = hub.ConnectionId
-                    
+
                     return!
                         match msg with
                         | HubMailbox.ProcessSends ->
@@ -231,7 +231,7 @@ type HubConnection<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi
                             loop waitingInvocations []
                         | HubMailbox.Send action ->
                             let newConnections =
-                                if hub.State = HubConnectionState.Connected then 
+                                if hub.State = HubConnectionState.Connected then
                                     action() |> fun a -> Async.Start(a, cts.Token)
                                     []
                                 else [ action ]
@@ -259,7 +259,7 @@ type HubConnection<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi
             loop Map.empty []
         , cancellationToken = cts.Token)
 
-    let onRsp rsp = 
+    let onRsp rsp =
         async {
             return
                 HubMailbox.ServerRsp (rsp.connectionId, rsp.invocationId, rsp.message)
@@ -267,15 +267,15 @@ type HubConnection<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi
         }
         |> Async.StartAsTask
         |> genTask
-        
+
     let invokeHandler =
         hub.Hub.On<InvokeArg<'ServerApi>>(HubMethod.Invoke, System.Func<_,_> onRsp)
 
-    do 
-        { handlers with 
+    do
+        { handlers with
             OnReconnected =
                 handlers.OnReconnected
-                |> Option.map(fun f -> 
+                |> Option.map(fun f ->
                     fun strOpt ->
                         mailbox.Post(HubMailbox.ProcessSends)
                         f strOpt)
@@ -289,11 +289,11 @@ type HubConnection<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi
                 do! hub.Hub.DisposeAsync().AsTask() |> Async.AwaitTask
                 do cts.Cancel()
                 do cts.Dispose()
-                
+
                 return invokeHandler.Dispose()
             }
             |> Async.Start
-            
+
     interface Hub<'ClientApi,'ServerApi> with
         member this.ConnectionId = this.ConnectionId
         member this.Invoke msg = this.Invoke msg
@@ -311,39 +311,39 @@ type HubConnection<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi
         member this.StreamFrom msg = this.StreamFrom msg
 
     interface StreamHub.Bidrectional<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi,'ServerStreamApi>
-    
+
     /// The connectionId to the hub of this client.
     member _.ConnectionId = hub.ConnectionId
-    
+
     /// Invokes a hub method on the server.
-    /// 
-    /// The async returned by this method resolves when the server indicates it has finished invoking 
-    /// the method. When it finishes, the server has finished invoking the method. If the server 
+    ///
+    /// The async returned by this method resolves when the server indicates it has finished invoking
+    /// the method. When it finishes, the server has finished invoking the method. If the server
     /// method returns a result, it is produced as the result of resolving the async call.
     member _.Invoke (msg: 'ClientApi) =
         mailbox.PostAndAsyncReply(fun reply -> HubMailbox.StartInvocation(msg, reply))
 
     /// Default interval at which to ping the server.
-    /// 
+    ///
     /// The default value is 15,000 milliseconds (15 seconds).
     /// Allows the server to detect hard disconnects (like when a client unplugs their computer).
     member _.KeepAliveInterval = hub.KeepAliveInterval
-    
+
     /// Registers a handler that will be invoked when the connection is closed.
     member _.OnClosed (callback: (exn option -> Async<unit>)) = hub.OnClosed(callback)
 
     /// Callback when a new message is recieved.
     member _.OnMessage (callback: 'ServerApi -> Async<unit>) = hub.OnMessage(callback)
-    
+
     /// Callback when the connection successfully reconnects.
     member _.OnReconnected (callback: (string option -> Async<unit>)) = hub.OnReconnected(callback)
 
     /// Callback when the connection starts reconnecting.
     member _.OnReconnecting (callback: (exn option -> Async<unit>)) = hub.OnReconnecting(callback)
-        
+
     /// Invokes a hub method on the server. Does not wait for a response from the receiver.
-    /// 
-    /// The async returned by this method resolves when the client has sent the invocation to the server. 
+    ///
+    /// The async returned by this method resolves when the client has sent the invocation to the server.
     /// The server may still be processing the invocation.
     member _.Send (msg: 'ClientApi, ?cancellationToken: CancellationToken) =
         let ct = getLinkedCT cancellationToken
@@ -351,42 +351,42 @@ type HubConnection<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi
         async { return mailbox.Post(HubMailbox.Send(fun () -> hub.Send(msg, ct))) }
 
     /// Invokes a hub method on the server. Does not wait for a response from the receiver.
-    member this.SendNow (msg: 'ClientApi, ?cancellationToken: CancellationToken) = 
+    member this.SendNow (msg: 'ClientApi, ?cancellationToken: CancellationToken) =
         let ct = getLinkedCT cancellationToken
 
-        this.Send(msg, ct) 
+        this.Send(msg, ct)
         |> fun a -> Async.Start(a, ct)
 
     /// The server timeout in milliseconds.
-    /// 
-    /// If this timeout elapses without receiving any messages from the server, the connection will be 
+    ///
+    /// If this timeout elapses without receiving any messages from the server, the connection will be
     /// terminated with an error.
     ///
     /// The default timeout value is 30,000 milliseconds (30 seconds).
     member _.ServerTimeout = hub.ServerTimeout
-    
+
     /// Starts the connection.
-    member _.Start (?cancellationToken: CancellationToken) = 
+    member _.Start (?cancellationToken: CancellationToken) =
         let ct = getLinkedCT cancellationToken
 
         async {
-            if hub.State = HubConnectionState.Disconnected then 
+            if hub.State = HubConnectionState.Disconnected then
                 do! hub.Start(ct)
                 mailbox.Post(HubMailbox.ProcessSends)
         }
 
     /// Starts the connection immediately.
-    member this.StartNow (?cancellationToken: CancellationToken) = 
+    member this.StartNow (?cancellationToken: CancellationToken) =
         let ct = getLinkedCT cancellationToken
 
-        this.Start(ct) 
+        this.Start(ct)
         |> fun a -> Async.Start(a, ct)
 
     /// The state of the hub connection to the server.
     member _.State = hub.State
-    
+
     /// Stops the connection.
-    member _.Stop (?cancellationToken: CancellationToken) = 
+    member _.Stop (?cancellationToken: CancellationToken) =
         let ct = getLinkedCT cancellationToken
 
         async {
@@ -395,17 +395,19 @@ type HubConnection<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi
         }
 
     /// Stops the connection immediately.
-    member this.StopNow (?cancellationToken: CancellationToken) = 
+    member this.StopNow (?cancellationToken: CancellationToken) =
         let ct = getLinkedCT cancellationToken
 
-        this.Stop(ct) 
+        this.Stop(ct)
         |> fun a -> Async.Start(a, ct)
-    
+
     /// Streams from the hub.
-    member _.StreamFrom (msg: 'ClientStreamFromApi) = 
-        mailbox.PostAndAsyncReply <| fun reply -> 
-            HubMailbox.Send <| fun () -> 
-                async { return reply.Reply(hub.StreamFrom(msg)) }
+    member _.StreamFrom (msg: 'ClientStreamFromApi, ?cancellationToken: CancellationToken) =
+        let ct = getLinkedCT cancellationToken
+
+        mailbox.PostAndAsyncReply <| fun reply ->
+            HubMailbox.Send <| fun () ->
+                async { return reply.Reply(hub.StreamFrom(msg, ct)) }
 
     /// Returns an async that when invoked, starts streaming to the hub.
     member _.StreamTo (asyncEnum: IAsyncEnumerable<'ClientStreamToApi>, ?cancellationToken: CancellationToken) =
@@ -417,6 +419,5 @@ type HubConnection<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi
     member this.StreamToNow (asyncEnum: IAsyncEnumerable<'ClientStreamToApi>, ?cancellationToken: CancellationToken) =
         let ct = getLinkedCT cancellationToken
 
-        this.StreamTo(asyncEnum, ct) 
+        this.StreamTo(asyncEnum, ct)
         |> fun a -> Async.StartImmediate(a, ct)
-    


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request. -->
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build (`fake build` or `.\build.cmd`) on local branch was successful

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
No ability to pass a `CancellationToken` to `HubConnection<...>.StreamFrom` in the .NET client.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
`StreamFrom` now accepts an optional `CancellationToken`, just like other streaming methods.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No (the parameter is optional)

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Fixes #32