### PR TITLE
Provide server streamFrom implementations are provided with the necessary CancellationToken

### DIFF
--- a/demo/Server/SignalR.fs
+++ b/demo/Server/SignalR.fs
@@ -1,11 +1,12 @@
 ﻿namespace SignalRApp
 
 module SignalRHub =
+    open System.Threading
     open Fable.SignalR
     open FSharp.Control
     open FSharp.Control.Tasks.V2
     open SignalRHub
-    
+
     let update (msg: Action) =
         match msg with
         | Action.IncrementCount i -> Response.NewCount(i + 1)
@@ -17,10 +18,10 @@ module SignalRHub =
     let send (msg: Action) (hubContext: FableHub<Action,Response>) =
         update msg
         |> hubContext.Clients.Caller.Send
-    
+
     [<RequireQualifiedAccess>]
     module Stream =
-        let sendToClient (msg: StreamFrom.Action) (hubContext: FableHub<Action,Response>) =
+        let sendToClient (msg: StreamFrom.Action) (hubContext: FableHub<Action,Response>) (_: CancellationToken) =
             match msg with
             | StreamFrom.Action.AppleStocks ->
                 Stocks.appleStocks

--- a/docs/signalr-server/aspnetcore.md
+++ b/docs/signalr-server/aspnetcore.md
@@ -145,8 +145,7 @@ module Endpoints =
 
 If you want to support streaming either from the client and/or the
 server you need to define the behavior you want:
-* Streaming from - A function that takes a streaming message (`StreamFrom.Action`) 
-and hub context that then returns an `IAsyncEnumerable<StreamFrom.Response>`.
+* Streaming from - A function that takes a streaming message (`StreamFrom.Action`), hub context, and a `CancellationToken` that signals that the stream should stop, then returns an `IAsyncEnumerable<StreamFrom.Response>`.
 * Streaming to - A function that takes a `IAsyncEnumerable<StreamTo.Action>` and a hub context
 and then (maybe) responds (with a `Response`).
 
@@ -161,6 +160,7 @@ module SignalRHub =
     open FSharp.Control.Tasks.V2
     open SignalRHub
     open System.Collections.Generic
+    open System.Threading
 
     let update (msg: Action) =
         match msg with
@@ -176,7 +176,7 @@ module SignalRHub =
 
     [<RequireQualifiedAccess>]
     module Stream =
-        let sendToClient (msg: StreamFrom.Action) (hubContext: FableHub<Action,Response>) =
+        let sendToClient (msg: StreamFrom.Action) (hubContext: FableHub<Action,Response>) (cancellationToken: CancellationToken) =
             match msg with
             | StreamFrom.Action.GenInts ->
                 asyncSeq {

--- a/docs/signalr-server/saturn.md
+++ b/docs/signalr-server/saturn.md
@@ -133,8 +133,7 @@ module Endpoints =
 
 If you want to support streaming either from the client and/or the
 server you need to define the behavior you want:
-* Streaming from - A function that takes a streaming message (`StreamFrom.Action`) 
-and hub context that then returns an `IAsyncEnumerable<StreamFrom.Response>`.
+* Streaming from - A function that takes a streaming message (`StreamFrom.Action`) , hub context, and a `CancellationToken` that signals that the stream should stop,  that then returns an `IAsyncEnumerable<StreamFrom.Response>`.
 * Streaming to - A function that takes a `IAsyncEnumerable<StreamTo.Action>` and a hub context
 and then (maybe) responds (with a `Response`).
 
@@ -149,6 +148,7 @@ module SignalRHub =
     open FSharp.Control.Tasks.V2
     open SignalRHub
     open System.Collections.Generic
+    open System.Threading
 
     let update (msg: Action) =
         match msg with
@@ -164,7 +164,7 @@ module SignalRHub =
 
     [<RequireQualifiedAccess>]
     module Stream =
-        let sendToClient (msg: StreamFrom.Action) (hubContext: FableHub<Action,Response>) =
+        let sendToClient (msg: StreamFrom.Action) (hubContext: FableHub<Action,Response>) (cancellationToken: CancellationToken) =
             match msg with
             | StreamFrom.Action.GenInts ->
                 asyncSeq {

--- a/src/Fable.SignalR.AspNetCore/Server.fs
+++ b/src/Fable.SignalR.AspNetCore/Server.fs
@@ -8,6 +8,7 @@ open Microsoft.Extensions.DependencyInjection
 open System
 open System.Collections.Generic
 open System.ComponentModel
+open System.Threading
 open System.Threading.Tasks
 
 type IFableHubCallerClients<'ServerApi when 'ServerApi : not struct> =
@@ -35,9 +36,9 @@ type FableHub<'ClientApi,'ServerApi when 'ClientApi : not struct and 'ServerApi 
 module internal DIHelpers =
     let injectFableHub<'Hub,'ClientApi,'ServerApi when 'Hub :> FableHub<'ClientApi,'ServerApi> and 'Hub :> Hub<IFableHubCallerClients<'ServerApi>>> (services: IServiceCollection) =
         services.AddSingleton<FableHubCaller<'ClientApi,'ServerApi>>(fun (s: IServiceProvider) ->
-            s.GetRequiredService<IHubContext<'Hub,IFableHubCallerClients<'ServerApi>>>() 
+            s.GetRequiredService<IHubContext<'Hub,IFableHubCallerClients<'ServerApi>>>()
             |> fun hub ->
-                { new FableHubCaller<'ClientApi,'ServerApi> with 
+                { new FableHubCaller<'ClientApi,'ServerApi> with
                     member _.Clients = hub.Clients
                     member _.Groups = hub.Groups }
         )
@@ -50,9 +51,9 @@ type BaseFableHubOptions<'ClientApi,'ServerApi when 'ClientApi : not struct and 
       Invoke: 'ClientApi -> FableHub -> Task<'ServerApi>
       Services: System.IServiceProvider }
 
-and [<EditorBrowsable(EditorBrowsableState.Never)>] BaseFableHub<'ClientApi,'ServerApi when 'ClientApi : not struct and 'ServerApi : not struct> 
+and [<EditorBrowsable(EditorBrowsableState.Never)>] BaseFableHub<'ClientApi,'ServerApi when 'ClientApi : not struct and 'ServerApi : not struct>
     (settings: BaseFableHubOptions<'ClientApi,'ServerApi>) =
-    
+
     inherit Hub<IFableHubCallerClients<'ServerApi>>()
 
     interface FableHub<'ClientApi,'ServerApi> with
@@ -61,7 +62,7 @@ and [<EditorBrowsable(EditorBrowsableState.Never)>] BaseFableHub<'ClientApi,'Ser
         member this.Groups = this.Groups
         member this.Dispose () = this.Dispose()
         member _.Services = settings.Services
-        
+
     member this.Invoke (msg: 'ClientApi, invocationId: System.Guid) =
         task {
             let! message = settings.Invoke msg (this :> FableHub)
@@ -83,13 +84,13 @@ type StreamFromFableHubOptions<'ClientApi,'ClientStreamApi,'ServerApi,'ServerStr
 
     { Send: 'ClientApi -> FableHub<'ClientApi,'ServerApi> -> Task
       Invoke: 'ClientApi -> FableHub -> Task<'ServerApi>
-      StreamFrom: 'ClientStreamApi -> FableHub<'ClientApi,'ServerApi> -> IAsyncEnumerable<'ServerStreamApi>
+      StreamFrom: 'ClientStreamApi -> FableHub<'ClientApi,'ServerApi> -> CancellationToken -> IAsyncEnumerable<'ServerStreamApi>
       Services: System.IServiceProvider }
 
 and [<EditorBrowsable(EditorBrowsableState.Never)>] StreamFromFableHub<'ClientApi,'ClientStreamApi,'ServerApi,'ServerStreamApi
     when 'ClientApi : not struct and 'ServerApi : not struct>
     (settings: StreamFromFableHubOptions<'ClientApi,'ClientStreamApi,'ServerApi,'ServerStreamApi>) =
-        
+
     inherit Hub<IFableHubCallerClients<'ServerApi>>()
 
     interface FableHub<'ClientApi,'ServerApi> with
@@ -98,15 +99,15 @@ and [<EditorBrowsable(EditorBrowsableState.Never)>] StreamFromFableHub<'ClientAp
         member this.Groups = this.Groups
         member this.Dispose () = this.Dispose()
         member _.Services = settings.Services
-    
+
     member this.Invoke (msg: 'ClientApi, invocationId: System.Guid) =
         task {
             let! message = settings.Invoke msg (this :> FableHub)
             do! this.Clients.Caller.Invoke({ connectionId = this.Context.ConnectionId; invocationId = invocationId; message = message })
         } :> Task
-        
+
     member this.Send msg = settings.Send msg (this :> FableHub<'ClientApi,'ServerApi>)
-    member this.StreamFrom msg = settings.StreamFrom msg (this :> FableHub<'ClientApi,'ServerApi>)
+    member this.StreamFrom msg (cancellationToken: CancellationToken) = settings.StreamFrom msg (this :> FableHub<'ClientApi,'ServerApi>) cancellationToken
 
     static member AddServices (send, invoke, stream, s: IServiceCollection) =
         s.AddTransient<StreamFromFableHubOptions<'ClientApi,'ClientStreamApi,'ServerApi,'ServerStreamApi>>(
@@ -125,7 +126,7 @@ type [<EditorBrowsable(EditorBrowsableState.Never)>] StreamToFableHubOptions<'Cl
 and [<EditorBrowsable(EditorBrowsableState.Never)>] StreamToFableHub<'ClientApi,'ClientStreamApi,'ServerApi
     when 'ClientApi : not struct and 'ServerApi : not struct>
     (settings: StreamToFableHubOptions<'ClientApi,'ClientStreamApi,'ServerApi>) =
-        
+
     inherit Hub<IFableHubCallerClients<'ServerApi>>()
 
     interface FableHub<'ClientApi,'ServerApi> with
@@ -134,7 +135,7 @@ and [<EditorBrowsable(EditorBrowsableState.Never)>] StreamToFableHub<'ClientApi,
         member this.Groups = this.Groups
         member this.Dispose () = this.Dispose()
         member _.Services = settings.Services
-        
+
     member this.Invoke (msg: 'ClientApi, invocationId: System.Guid) =
         task {
             let! message = settings.Invoke msg (this :> FableHub)
@@ -155,14 +156,14 @@ type [<EditorBrowsable(EditorBrowsableState.Never)>] StreamBothFableHubOptions<'
 
     { Send: 'ClientApi -> FableHub<'ClientApi,'ServerApi> -> Task
       Invoke: 'ClientApi -> FableHub -> Task<'ServerApi>
-      StreamFrom: 'ClientStreamFromApi -> FableHub<'ClientApi,'ServerApi> -> IAsyncEnumerable<'ServerStreamApi>
+      StreamFrom: 'ClientStreamFromApi -> FableHub<'ClientApi,'ServerApi> -> CancellationToken -> IAsyncEnumerable<'ServerStreamApi>
       StreamTo: IAsyncEnumerable<'ClientStreamToApi> -> FableHub<'ClientApi,'ServerApi> -> Task
       Services: System.IServiceProvider }
 
 and [<EditorBrowsable(EditorBrowsableState.Never)>] StreamBothFableHub<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi,'ServerStreamApi
     when 'ClientApi : not struct and 'ServerApi : not struct>
     (settings: StreamBothFableHubOptions<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi,'ServerStreamApi>) =
-        
+
     inherit Hub<IFableHubCallerClients<'ServerApi>>()
 
     interface FableHub<'ClientApi,'ServerApi> with
@@ -171,14 +172,14 @@ and [<EditorBrowsable(EditorBrowsableState.Never)>] StreamBothFableHub<'ClientAp
         member this.Groups = this.Groups
         member this.Dispose () = this.Dispose()
         member _.Services = settings.Services
-        
+
     member this.Invoke (msg: 'ClientApi, invocationId: System.Guid) =
         task {
             let! message = settings.Invoke msg (this :> FableHub)
             do! this.Clients.Caller.Invoke({ connectionId = this.Context.ConnectionId; invocationId = invocationId; message = message })
         } :> Task
     member this.Send msg = settings.Send msg (this :> FableHub<'ClientApi,'ServerApi>)
-    member this.StreamFrom msg = settings.StreamFrom msg (this :> FableHub<'ClientApi,'ServerApi>)
+    member this.StreamFrom msg (cancellationToken: CancellationToken) = settings.StreamFrom msg (this :> FableHub<'ClientApi,'ServerApi>) cancellationToken
     member this.StreamTo msg = settings.StreamTo msg (this :> FableHub<'ClientApi,'ServerApi>)
 
     static member AddServices (send, invoke, streamFrom, streamTo, s: IServiceCollection) =
@@ -207,14 +208,14 @@ module FableHub =
                 { Send = this.Send
                   Invoke = this.Invoke
                   Services = this.Services }
-    
+
     type OnConnected<'ClientApi,'ServerApi
-        when 'ClientApi : not struct and 'ServerApi : not struct> 
+        when 'ClientApi : not struct and 'ServerApi : not struct>
         (settings: OnConnected.IOverride<'ClientApi,'ServerApi>) =
 
         inherit BaseFableHub<'ClientApi,'ServerApi>(settings.AsNormalOptions)
 
-        override this.OnConnectedAsync () = 
+        override this.OnConnectedAsync () =
             this :> FableHub<'ClientApi,'ServerApi>
             |> settings.OnConnected :> Task
 
@@ -237,7 +238,7 @@ module FableHub =
                 { Send = this.Send
                   Invoke = this.Invoke
                   Services = this.Services }
-    
+
     type OnDisconnected<'ClientApi,'ServerApi
         when 'ClientApi : not struct and 'ServerApi : not struct>
         (settings: OnDisconnected.IOverride<'ClientApi,'ServerApi>) =
@@ -270,7 +271,7 @@ module FableHub =
                   Services = this.Services }
 
     type Both<'ClientApi,'ServerApi
-        when 'ClientApi : not struct and 'ServerApi : not struct> 
+        when 'ClientApi : not struct and 'ServerApi : not struct>
         (settings: Both.IOverride<'ClientApi,'ServerApi>) =
 
         inherit BaseFableHub<'ClientApi,'ServerApi>(settings.AsNormalOptions)
@@ -297,19 +298,19 @@ module FableHub =
 
                     { Send: 'ClientApi -> FableHub<'ClientApi,'ServerApi> -> Task
                       Invoke: 'ClientApi -> FableHub -> Task<'ServerApi>
-                      StreamFrom: 'ClientStreamFromApi -> FableHub<'ClientApi,'ServerApi> -> IAsyncEnumerable<'ServerStreamApi>
+                      StreamFrom: 'ClientStreamFromApi -> FableHub<'ClientApi,'ServerApi> -> CancellationToken -> IAsyncEnumerable<'ServerStreamApi>
                       StreamTo: IAsyncEnumerable<'ClientStreamToApi> -> FableHub<'ClientApi,'ServerApi> -> Task
                       OnConnected: FableHub<'ClientApi,'ServerApi> -> Task<unit>
                       Services: System.IServiceProvider }
-        
+
             type OnConnected<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi,'ServerStreamApi
-                when 'ClientApi : not struct and 'ServerApi : not struct> 
+                when 'ClientApi : not struct and 'ServerApi : not struct>
                 (settings: OnConnected.IOverride<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi,'ServerStreamApi>) =
 
                 inherit StreamBothFableHub<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi,'ServerStreamApi>
                     ({ Send = settings.Send; Invoke = settings.Invoke; StreamFrom = settings.StreamFrom; StreamTo = settings.StreamTo; Services = settings.Services })
 
-                override this.OnConnectedAsync () = 
+                override this.OnConnectedAsync () =
                     this :> FableHub<'ClientApi,'ServerApi>
                     |> settings.OnConnected :> Task
 
@@ -325,11 +326,11 @@ module FableHub =
 
                     { Send: 'ClientApi -> FableHub<'ClientApi,'ServerApi> -> Task
                       Invoke: 'ClientApi -> FableHub -> Task<'ServerApi>
-                      StreamFrom: 'ClientStreamFromApi -> FableHub<'ClientApi,'ServerApi> -> IAsyncEnumerable<'ServerStreamApi>
+                      StreamFrom: 'ClientStreamFromApi -> FableHub<'ClientApi,'ServerApi> -> CancellationToken -> IAsyncEnumerable<'ServerStreamApi>
                       StreamTo: IAsyncEnumerable<'ClientStreamToApi> -> FableHub<'ClientApi,'ServerApi> -> Task
                       OnDisconnected: exn -> FableHub<'ClientApi,'ServerApi> -> Task<unit>
                       Services: System.IServiceProvider }
-        
+
             type OnDisconnected<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi,'ServerStreamApi
                 when 'ClientApi : not struct and 'ServerApi : not struct>
                 (settings: OnDisconnected.IOverride<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi,'ServerStreamApi>) =
@@ -353,14 +354,14 @@ module FableHub =
 
                     { Send: 'ClientApi -> FableHub<'ClientApi,'ServerApi> -> Task
                       Invoke: 'ClientApi -> FableHub -> Task<'ServerApi>
-                      StreamFrom: 'ClientStreamFromApi -> FableHub<'ClientApi,'ServerApi> -> IAsyncEnumerable<'ServerStreamApi>
+                      StreamFrom: 'ClientStreamFromApi -> FableHub<'ClientApi,'ServerApi> -> CancellationToken -> IAsyncEnumerable<'ServerStreamApi>
                       StreamTo: IAsyncEnumerable<'ClientStreamToApi> -> FableHub<'ClientApi,'ServerApi> -> Task
                       OnConnected: FableHub<'ClientApi,'ServerApi> -> Task<unit>
                       OnDisconnected: exn -> FableHub<'ClientApi,'ServerApi> -> Task<unit>
                       Services: System.IServiceProvider }
 
             type Both<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi,'ServerStreamApi
-                when 'ClientApi : not struct and 'ServerApi : not struct> 
+                when 'ClientApi : not struct and 'ServerApi : not struct>
                 internal (settings: Both.IOverride<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi,'ServerStreamApi>) =
 
                 inherit StreamBothFableHub<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi,'ServerStreamApi>
@@ -387,17 +388,17 @@ module FableHub =
 
                     { Send: 'ClientApi -> FableHub<'ClientApi,'ServerApi> -> Task
                       Invoke: 'ClientApi -> FableHub -> Task<'ServerApi>
-                      Stream: 'ClientStreamApi -> FableHub<'ClientApi,'ServerApi> -> IAsyncEnumerable<'ServerStreamApi>
+                      Stream: 'ClientStreamApi -> FableHub<'ClientApi,'ServerApi> -> CancellationToken -> IAsyncEnumerable<'ServerStreamApi>
                       OnConnected: FableHub<'ClientApi,'ServerApi> -> Task<unit>
                       Services: System.IServiceProvider }
-        
+
             type OnConnected<'ClientApi,'ClientStreamApi,'ServerApi,'ServerStreamApi
-                when 'ClientApi : not struct and 'ServerApi : not struct> 
+                when 'ClientApi : not struct and 'ServerApi : not struct>
                 (settings: OnConnected.IOverride<'ClientApi,'ClientStreamApi,'ServerApi,'ServerStreamApi>) =
 
                 inherit StreamFromFableHub<'ClientApi,'ClientStreamApi,'ServerApi,'ServerStreamApi>({ Send = settings.Send; Invoke = settings.Invoke; StreamFrom = settings.Stream; Services = settings.Services })
 
-                override this.OnConnectedAsync () = 
+                override this.OnConnectedAsync () =
                     this :> FableHub<'ClientApi,'ServerApi>
                     |> settings.OnConnected :> Task
 
@@ -413,10 +414,10 @@ module FableHub =
 
                     { Send: 'ClientApi -> FableHub<'ClientApi,'ServerApi> -> Task
                       Invoke: 'ClientApi -> FableHub -> Task<'ServerApi>
-                      Stream: 'ClientStreamApi -> FableHub<'ClientApi,'ServerApi> -> IAsyncEnumerable<'ServerStreamApi>
+                      Stream: 'ClientStreamApi -> FableHub<'ClientApi,'ServerApi> -> CancellationToken -> IAsyncEnumerable<'ServerStreamApi>
                       OnDisconnected: exn -> FableHub<'ClientApi,'ServerApi> -> Task<unit>
                       Services: System.IServiceProvider }
-        
+
             type OnDisconnected<'ClientApi,'ClientStreamApi,'ServerApi,'ServerStreamApi
                 when 'ClientApi : not struct and 'ServerApi : not struct>
                 (settings: OnDisconnected.IOverride<'ClientApi,'ClientStreamApi,'ServerApi,'ServerStreamApi>) =
@@ -439,13 +440,13 @@ module FableHub =
 
                     { Send: 'ClientApi -> FableHub<'ClientApi,'ServerApi> -> Task
                       Invoke: 'ClientApi -> FableHub -> Task<'ServerApi>
-                      Stream: 'ClientStreamApi -> FableHub<'ClientApi,'ServerApi> -> IAsyncEnumerable<'ServerStreamApi>
+                      Stream: 'ClientStreamApi -> FableHub<'ClientApi,'ServerApi> -> CancellationToken -> IAsyncEnumerable<'ServerStreamApi>
                       OnConnected: FableHub<'ClientApi,'ServerApi> -> Task<unit>
                       OnDisconnected: exn -> FableHub<'ClientApi,'ServerApi> -> Task<unit>
                       Services: System.IServiceProvider }
 
             type Both<'ClientApi,'ClientStreamApi,'ServerApi,'ServerStreamApi
-                when 'ClientApi : not struct and 'ServerApi : not struct> 
+                when 'ClientApi : not struct and 'ServerApi : not struct>
                 (settings: Both.IOverride<'ClientApi,'ClientStreamApi,'ServerApi,'ServerStreamApi>) =
 
                 inherit StreamFromFableHub<'ClientApi,'ClientStreamApi,'ServerApi,'ServerStreamApi>({ Send = settings.Send; Invoke = settings.Invoke; StreamFrom = settings.Stream; Services = settings.Services })
@@ -479,14 +480,14 @@ module FableHub =
                         { Send = this.Send
                           Invoke = this.Invoke
                           Services = this.Services }
-        
+
             type OnConnected<'ClientApi,'ClientStreamApi,'ServerApi
-                when 'ClientApi : not struct and 'ServerApi : not struct> 
+                when 'ClientApi : not struct and 'ServerApi : not struct>
                 (settings: OnConnected.IOverride<'ClientApi,'ClientStreamApi,'ServerApi>) =
 
                 inherit StreamToFableHub<'ClientApi,'ClientStreamApi,'ServerApi>({ Send = settings.Send; Invoke = settings.Invoke; StreamTo = settings.Stream; Services = settings.Services })
 
-                override this.OnConnectedAsync () = 
+                override this.OnConnectedAsync () =
                     this :> FableHub<'ClientApi,'ServerApi>
                     |> settings.OnConnected :> Task
 
@@ -505,7 +506,7 @@ module FableHub =
                       Stream: IAsyncEnumerable<'ClientStreamApi> -> FableHub<'ClientApi,'ServerApi> -> Task
                       OnDisconnected: exn -> FableHub<'ClientApi,'ServerApi> -> Task<unit>
                       Services: System.IServiceProvider }
-        
+
             type OnDisconnected<'ClientApi,'ClientStreamApi,'ServerApi
                 when 'ClientApi : not struct and 'ServerApi : not struct>
                 (settings: OnDisconnected.IOverride<'ClientApi,'ClientStreamApi,'ServerApi>) =
@@ -534,7 +535,7 @@ module FableHub =
                       Services: System.IServiceProvider }
 
             type Both<'ClientApi,'ClientStreamApi,'ServerApi
-                when 'ClientApi : not struct and 'ServerApi : not struct> 
+                when 'ClientApi : not struct and 'ServerApi : not struct>
                 (settings: Both.IOverride<'ClientApi,'ClientStreamApi,'ServerApi>) =
 
                 inherit StreamToFableHub<'ClientApi,'ClientStreamApi,'ServerApi>({ Send = settings.Send; Invoke = settings.Invoke; StreamTo = settings.Stream; Services = settings.Services })
@@ -552,7 +553,7 @@ module FableHub =
                         System.Func<System.IServiceProvider,Both.IOverride<'ClientApi,'ClientStreamApi,'ServerApi>>
                             (fun sp -> { Send = send; Invoke = invoke; Stream = stream; OnConnected = onConnected; OnDisconnected = onDisconnected; Services = sp }))
                     |> injectFableHub<Both<'ClientApi,'ClientStreamApi,'ServerApi>,'ClientApi,'ServerApi>
-        
+
 [<RequireQualifiedAccess>]
 module SignalR =
     /// Configuration options for customizing behavior of a SignalR hub.
@@ -565,7 +566,7 @@ module SignalR =
           /// Inject a Websocket middleware to support bearer tokens.
           ///
           /// Default: false
-          EnableBearerAuth: bool 
+          EnableBearerAuth: bool
           /// Customize hub endpoint conventions.
           EndpointConfig: (HubEndpointConventionBuilder -> HubEndpointConventionBuilder) option
           /// Options used to configure hub instances.
@@ -592,7 +593,7 @@ module SignalR =
             { AfterUseRouting = None
               BeforeUseRouting = None
               EnableBearerAuth = false
-              EndpointConfig = None 
+              EndpointConfig = None
               HubOptions = None
               LogLevel = None
               NoRouting = false
@@ -624,11 +625,11 @@ module SignalR =
             | None -> Config<'ClientApi,'ServerApi>.Default()
             | Some config -> config
 
-        static member internal Create (endpointPattern: string, update: 'ClientApi -> FableHub<'ClientApi,'ServerApi> -> Task, invoke: 'ClientApi -> FableHub -> Task<'ServerApi>) =    
+        static member internal Create (endpointPattern: string, update: 'ClientApi -> FableHub<'ClientApi,'ServerApi> -> Task, invoke: 'ClientApi -> FableHub -> Task<'ServerApi>) =
             ConfigBuilder<'ClientApi,'ServerApi>(endpointPattern, update, invoke)
 
-    and ConfigBuilder<'ClientApi,'ServerApi when 'ClientApi : not struct and 'ServerApi : not struct> 
-        (endpoint: string, 
+    and ConfigBuilder<'ClientApi,'ServerApi when 'ClientApi : not struct and 'ServerApi : not struct>
+        (endpoint: string,
          send: 'ClientApi -> FableHub<'ClientApi,'ServerApi> -> Task,
          invoke: 'ClientApi -> FableHub -> Task<'ServerApi>,
          ?config: Config<'ClientApi,'ServerApi>) =
@@ -680,7 +681,7 @@ module SignalR =
                             EndpointConfig = Some f }
                         |> Some }
             this
-        
+
         /// Options used to configure hub instances.
         member this.HubOptions (f: HubOptions -> unit) =
             state <-
@@ -690,7 +691,7 @@ module SignalR =
                             HubOptions = Some f }
                         |> Some }
             this
-            
+
         /// Adds a logging filter with the given LogLevel.
         member this.LogLevel (logLevel: Microsoft.Extensions.Logging.LogLevel) =
             state <-
@@ -700,7 +701,7 @@ module SignalR =
                             LogLevel = Some logLevel }
                         |> Some }
             this
-            
+
         /// Disable app.UseRouting() configuration.
         ///
         /// *You must configure this yourself if you do this!*
@@ -722,7 +723,7 @@ module SignalR =
                             OnConnected = Some f }
                         |> Some }
             this
-            
+
         /// Called when a connection with the hub is terminated.
         member this.OnDisconnected (f: exn -> FableHub<'ClientApi,'ServerApi> -> Task<unit>) =
             state <-
@@ -742,7 +743,7 @@ module SignalR =
                             UseMessagePack = true }
                         |> Some }
             this
-            
+
         /// Configure the SignalR server.
         member this.UseServerBuilder (handler: ISignalRServerBuilder -> ISignalRServerBuilder) =
             state <-

--- a/src/Fable.SignalR.Feliz/Feliz.fs
+++ b/src/Fable.SignalR.Feliz/Feliz.fs
@@ -7,34 +7,34 @@ module Feliz =
 
     [<RequireQualifiedAccess>]
     module Hub =
-        type Config<'ClientApi,'ServerApi> = 
-            HubConnectionBuilder<'ClientApi,unit,unit,'ServerApi,unit> 
+        type Config<'ClientApi,'ServerApi> =
+            HubConnectionBuilder<'ClientApi,unit,unit,'ServerApi,unit>
                 -> HubConnectionBuilder<'ClientApi,unit,unit,'ServerApi,unit>
 
     [<RequireQualifiedAccess>]
     module StreamHub =
-        type Bidrectional<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi,'ServerStreamApi> = 
+        type Bidrectional<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi,'ServerStreamApi> =
             Fable.React.IRefValue<StreamHub.Bidrectional<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi,'ServerStreamApi>>
 
         module Bidrectional =
-            type Config<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi,'ServerStreamApi> = 
-                HubConnectionBuilder<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi,'ServerStreamApi> 
+            type Config<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi,'ServerStreamApi> =
+                HubConnectionBuilder<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi,'ServerStreamApi>
                     -> HubConnectionBuilder<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi,'ServerStreamApi>
 
-        type ServerToClient<'ClientApi,'ClientStreamApi,'ServerApi,'ServerStreamApi> = 
+        type ServerToClient<'ClientApi,'ClientStreamApi,'ServerApi,'ServerStreamApi> =
             Fable.React.IRefValue<StreamHub.ServerToClient<'ClientApi,'ClientStreamApi,'ServerApi,'ServerStreamApi>>
 
         module ServerToClient =
-            type Config<'ClientApi,'ClientStreamApi,'ServerApi,'ServerStreamApi> = 
-                HubConnectionBuilder<'ClientApi,'ClientStreamApi,unit,'ServerApi,'ServerStreamApi> 
+            type Config<'ClientApi,'ClientStreamApi,'ServerApi,'ServerStreamApi> =
+                HubConnectionBuilder<'ClientApi,'ClientStreamApi,unit,'ServerApi,'ServerStreamApi>
                     -> HubConnectionBuilder<'ClientApi,'ClientStreamApi,unit,'ServerApi,'ServerStreamApi>
 
-        type ClientToServer<'ClientApi,'ClientStreamApi,'ServerApi> = 
+        type ClientToServer<'ClientApi,'ClientStreamApi,'ServerApi> =
             Fable.React.IRefValue<StreamHub.ClientToServer<'ClientApi,'ClientStreamApi,'ServerApi>>
 
         module ClientToServer =
-            type Config<'ClientApi,'ClientStreamApi,'ServerApi> = 
-                HubConnectionBuilder<'ClientApi,unit,'ClientStreamApi,'ServerApi,unit> 
+            type Config<'ClientApi,'ClientStreamApi,'ServerApi> =
+                HubConnectionBuilder<'ClientApi,unit,'ClientStreamApi,'ServerApi,unit>
                     -> HubConnectionBuilder<'ClientApi,unit,'ClientStreamApi,'ServerApi,unit>
 
     type React with
@@ -49,11 +49,11 @@ module Feliz =
             )
 
             React.useRef(connection.current :> Fable.SignalR.Hub<'ClientApi,'ServerApi>)
-        
-        static member inline useSignalR<'ClientApi,'ClientStreamApi,'ServerApi,'ServerStreamApi> 
+
+        static member inline useSignalR<'ClientApi,'ClientStreamApi,'ServerApi,'ServerStreamApi>
             (config: StreamHub.ServerToClient.Config<'ClientApi,'ClientStreamApi,'ServerApi,'ServerStreamApi>, ?dependencies: obj []) =
-            
-            let connection = React.useMemo((fun () -> 
+
+            let connection = React.useMemo((fun () ->
                 SignalR.connect<'ClientApi,'ClientStreamApi,_,'ServerApi,'ServerStreamApi>(config)), ?dependencies = dependencies)
             let connection = React.useRef(connection)
 
@@ -65,10 +65,10 @@ module Feliz =
 
             React.useRef(connection.current :> Fable.SignalR.StreamHub.ServerToClient<'ClientApi,'ClientStreamApi,'ServerApi,'ServerStreamApi>)
 
-        static member inline useSignalR<'ClientApi,'ClientStreamApi,'ServerApi> 
+        static member inline useSignalR<'ClientApi,'ClientStreamApi,'ServerApi>
             (config: StreamHub.ClientToServer.Config<'ClientApi,'ClientStreamApi,'ServerApi>, ?dependencies: obj []) =
-            
-            let connection = React.useMemo((fun () -> 
+
+            let connection = React.useMemo((fun () ->
                 SignalR.connect<'ClientApi,_,'ClientStreamApi,'ServerApi,_>(config)), ?dependencies = dependencies)
             let connection = React.useRef(connection)
 
@@ -80,11 +80,11 @@ module Feliz =
 
             React.useRef(connection.current :> Fable.SignalR.StreamHub.ClientToServer<'ClientApi,'ClientStreamApi,'ServerApi>)
 
-        static member inline useSignalR<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi,'ServerStreamApi> 
-            (config: StreamHub.Bidrectional.Config<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi,'ServerStreamApi>, 
+        static member inline useSignalR<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi,'ServerStreamApi>
+            (config: StreamHub.Bidrectional.Config<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi,'ServerStreamApi>,
              ?dependencies: obj []) =
-            
-            let connection = React.useMemo((fun () -> 
+
+            let connection = React.useMemo((fun () ->
                 SignalR.connect<'ClientApi,'ClientStreamFromApi,'ClientStreamToApi,'ServerApi,'ServerStreamApi>(config)), ?dependencies = dependencies)
             let connection = React.useRef(connection)
 

--- a/tests/Fable.SignalR.TestServer/SignalR.fs
+++ b/tests/Fable.SignalR.TestServer/SignalR.fs
@@ -1,11 +1,12 @@
 ﻿namespace SignalRApp
 
+open System.Threading
 open FSharp.Control.Tasks.V2
 
-type RandomStringGen () = 
+type RandomStringGen () =
     member _.Gen () =
         let characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-        
+
         System.Random().Next(0,characters.Length-1)
         |> fun i -> characters.ToCharArray().[i]
         |> string
@@ -17,7 +18,7 @@ module SignalRHub =
     open Microsoft.Extensions.DependencyInjection
     open SignalRHub
     open System.Collections.Generic
-    
+
     let update (msg: Action) (stringGen: RandomStringGen) =
         match msg with
         | Action.IncrementCount i -> Response.NewCount(i + 1)
@@ -30,7 +31,7 @@ module SignalRHub =
                 hubContext.Services.GetService<RandomStringGen>()
                 |> update msg
         }
-            
+
     let send (msg: Action) (hubContext: FableHub<Action,Response>) =
         task {
             let! response = invoke msg hubContext
@@ -39,7 +40,7 @@ module SignalRHub =
 
     [<RequireQualifiedAccess>]
     module Stream =
-        let sendToClient (msg: StreamFrom.Action) (_: FableHub<Action,Response>) =
+        let sendToClient (msg: StreamFrom.Action) (_: FableHub<Action,Response>) (_: CancellationToken) =
             match msg with
             | StreamFrom.Action.GenInts ->
                 asyncSeq {
@@ -65,7 +66,7 @@ module SignalRHub2 =
         | Action.DecrementCount i -> Response.NewCount(i - 1)
         | Action.RandomCharacter ->
             let characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-            
+
             System.Random().Next(0,characters.Length-1)
             |> fun i -> characters.ToCharArray().[i]
             |> string
@@ -82,7 +83,7 @@ module SignalRHub2 =
 
     [<RequireQualifiedAccess>]
     module Stream =
-        let sendToClient (msg: StreamFrom.Action) (_: FableHub<Action,Response>) =
+        let sendToClient (msg: StreamFrom.Action) (_: FableHub<Action,Response>) (_: CancellationToken) =
             match msg with
             | StreamFrom.Action.GenInts ->
                 asyncSeq {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3935,7 +3935,7 @@ debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "2.1.2"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -6560,7 +6560,7 @@ import-local@^3.0.2:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -7945,11 +7945,6 @@ lockfile@~1.0.3:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -7958,32 +7953,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._root@~3.0.0:
   version "3.0.1"
@@ -8004,11 +7977,6 @@ lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -10514,7 +10482,7 @@ readable-stream@~1.1.10:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz#8d45407b4f870a0dcaebc0e28670d18e74514309"
   integrity sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==
@@ -13062,7 +13030,7 @@ v8-to-istanbul@^7.0.0:
     convert-source-map "^1.6.0"
     source-map "^0.7.3"
 
-validate-npm-package-license@*, validate-npm-package-license@^3.0.1:
+validate-npm-package-license@^3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
   integrity sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request. -->
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Build (`fake build` or `.\build.cmd`) on local branch was successful

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Server to client stream implementations are not provided with a `CancellationToken` that signals clients disconnecting from the stream. Hence, long-lived streams will continue to stay alive indefinitely. The best the implementation can currently do is use `FableHub<...>.HubContext.ConnectionAborted`, but this will only trigger when the client disconnects. Long-lived clients will cause streams to remain open indefinitely.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Server-to-client stream implementations are required to accept a `CancellationToken` parameter. This token is provided directly by SignalR and is triggered whenever clients cancel a stream (or if the client disconnects).

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [X] Yes
- [ ] No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
Sorry again for whitespace changes. There is a ton of dangling whitespace in this code base, so figured it makes sense to clean up as I go rather than disable the extension I have for this.

Fixes #34